### PR TITLE
:lips: infinite scroll & search fn feature on mentees and mentors page

### DIFF
--- a/pages/mentors.vue
+++ b/pages/mentors.vue
@@ -1,41 +1,80 @@
 <template>
   <div class="container">
     <h1>Mentors</h1>
-    <input v-model="filter" class="filter" placeholder="Filter Mentors">
+    <input v-model="search.keyword" class="filter" placeholder="Search in Mentors" @input="searchMentor">
     <ul class="persons">
+      <h5 v-if="postList.mentor.items.length <= 0">
+        No results...
+      </h5>
       <Card
-        v-for="(mentor, index) in filteredMentors"
+        v-for="(mentor, index) in postList.mentor.items"
+        v-else
         :key="index"
         class="person"
         :person="mentor"
         person-type="mentor"
       />
     </ul>
+    <client-only>
+      <infinite-loading v-if="postList.mentor.items.length >= postList.mentor.limit && !search.isFilled" @infinite="loadMoreMentors" />
+    </client-only>
   </div>
 </template>
 
 <script>
 export default {
-  async asyncData ({ $content, params }) {
-    const mentors = await $content('persons').where({ mentor: { $in: ['Mentor', 'İkisi de'] } }).fetch()
-    return { mentors }
+  async fetch () {
+    this.postList.mentor.items = await this.$content('persons').where({ mentor: { $in: ['Mentor', 'İkisi de'] } })
+      .limit(this.postList.mentor.limit)
+      .skip(this.postList.mentor.skip)
+      .fetch()
   },
   data () {
     return {
-      filter: null
+      search: {
+        keyword: null,
+        isFilled: false
+      },
+      postList: {
+        mentor: {
+          items: [],
+          limit: 16,
+          skip: 0
+        }
+      }
     }
   },
-  computed: {
-    filteredMentors () {
-      if (this.filter) {
-        return this.mentors.filter((mentor) => {
-          return this.filter
-            .toLowerCase()
-            .split(' ')
-            .every(v => mentor.name.toLowerCase().includes(v))
-        })
+  methods: {
+    async loadMoreMentors ($state) {
+      this.postList.mentor.skip += this.postList.mentor.limit
+
+      const mentors = await this.$content('persons')
+        .where({ mentor: { $in: ['Mentor', 'İkisi de'] } })
+        .limit(this.postList.mentor.limit)
+        .skip(this.postList.mentor.skip)
+        .fetch()
+
+      this.postList.mentor.items.push(...mentors)
+      $state.loaded()
+
+      if (mentors.length <= 0) {
+        $state.complete()
+      }
+    },
+    async searchMentor () {
+      const result = await this.$content('persons')
+        .where({ mentor: { $in: ['Mentor', 'İkisi de'] } })
+        .search(this.search.keyword)
+        .fetch()
+
+      if (this.search.keyword.length > 0) {
+        this.search.isFilled = true
+
+        this.postList.mentor.items = result
       } else {
-        return this.mentors
+        this.postList.mentor.skip = 0
+        this.$fetch()
+        this.search.isFilled = false
       }
     }
   }


### PR DESCRIPTION
#43 

Artık Mentees ve Mentors sayfalarında infinite scroll/loading özelliği mevcut. 

Bu sayfalardaki dönen listeler için filtered items bağımlılığını kaldırdım. Bu PR kapsamındaki temel amaç sayfalama yapmaktı bu computed bağımlılıkları engel oluyordu.

Var olan person list arrayde filtreleme yerine direkt olarak nuxt content search yapısı ile json içerisindeki ilgili fieldlarda arama işlemi sağlandı. Arama inputu dolu olduğunda infinite scroll deaktif haldedir. Sadece arama inputu boş iken infinite scroll yapılabilir. Arama işlemi tüm jsonda yapılıyor. Bu sebeple veriler arttığında arama alanları için ilerleyen süreçte UX ve Performansa yönelik (Arama ile birlikte sayfalama gibi) iyileştirilmek üzere plana alınabilir.