### PR TITLE
🐛 Check for peer is exist fixed

### DIFF
--- a/pages/peer/_slug.vue
+++ b/pages/peer/_slug.vue
@@ -41,10 +41,13 @@ export default {
   async fetch() {
     const { $content, params, error } = this.$nuxt.context
 
-    const result = await $content('persons')
+    const [person] = await $content('persons')
       .where({ slug: { $eq: params.slug } })
       .fetch()
-    const person = result[0]
+
+    if (!person) {
+      return error({ statusCode: 404, message: 'Not found' })
+    }
 
     this.person = person
 
@@ -55,10 +58,6 @@ export default {
 
     this.navigation.person.prev = prev
     this.navigation.person.next = next
-
-    if (!result) {
-      return error({ statusCode: 404, message: 'Not found' })
-    }
   },
   data() {
     return {


### PR DESCRIPTION
In the current situation if there is no peer, an error occurring in the console and the page is not loading. I fixed the check part for redirect to 404 page.