### PR TITLE
Make Header Content Fit on Smaller Screens

### DIFF
--- a/components/button/CtaButton.vue
+++ b/components/button/CtaButton.vue
@@ -69,13 +69,13 @@ export default {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  min-width: 140px;
+  min-width: 128px;
   padding: 8px 16px;
   border: 0;
-  border-radius: 32px;
+  border-radius: 24px;
   outline: none;
   box-shadow: var(--shadow-1);
-  font-size: 18px;
+  font-size: 16px;
   text-decoration: none;
   text-align: center;
 }

--- a/components/header/AppHeader.vue
+++ b/components/header/AppHeader.vue
@@ -66,7 +66,7 @@ export default {
   }
 
   .search {
-    margin-right: 8px;
+    margin-right: 16px;
   }
 
   .cta-button {

--- a/components/header/AppHeader.vue
+++ b/components/header/AppHeader.vue
@@ -1,5 +1,5 @@
 <template>
-  <b-navbar :class="`header app-header ${revealClass}`" toggleable="lg" :type="$colorMode.value" :variant="$colorMode.value">
+  <b-navbar :class="`header app-header ${revealClass}`" toggleable="xl" :type="$colorMode.value" :variant="$colorMode.value">
     <b-navbar-brand to="/">
       <FmLogo :width="40" :height="40" />
     </b-navbar-brand>
@@ -16,7 +16,7 @@
         <b-nav-item exact to="/jobs" active-class="active"> Jobs </b-nav-item>
         <b-nav-item exact to="/hire" active-class="active"> Job Seekers </b-nav-item>
       </b-navbar-nav>
-      <b-navbar-nav class="col col-12 col-lg-3 col-xl-2">
+      <b-navbar-nav class="ml-auto search">
         <app-search-input class="ml-md-2" @searchTriggered="isCollapsed = false" />
       </b-navbar-nav>
       <b-navbar-nav class="ml-auto" right>
@@ -53,10 +53,11 @@ export default {
   top: 0;
   left: 0;
   width: 100%;
+  font-size: 0.9rem;
   height: var(--header-height);
   z-index: var(--z-index-header);
 
-  @include mq($until: desktop) {
+  @include mq($until: wide) {
     height: auto;
   }
 
@@ -64,8 +65,12 @@ export default {
     height: 40px;
   }
 
+  .search {
+    margin-right: 8px;
+  }
+
   .cta-button {
-    @include mq($until: desktop) {
+    @include mq($until: wide) {
       margin-top: 14px;
     }
   }

--- a/components/input/AppSearchInput.vue
+++ b/components/input/AppSearchInput.vue
@@ -80,6 +80,11 @@ export default {
     border-radius: var(--border-radius-base);
     outline: 0;
     box-shadow: none !important;
+    text-overflow: ellipsis;
+  }
+
+  .form-control {
+    font-size: 0.8rem;
   }
 
   &__searchButton {


### PR DESCRIPTION
This addresses #249. Font size and collapse behavior of navbar is slightly changed.

Full:
<img width="1392" alt="Screen Shot 2021-01-02 at 17 20 06" src="https://user-images.githubusercontent.com/1009191/103459248-ef0e9500-4d1e-11eb-89a0-4b61b4b9ba93.png">

Smaller:
<img width="1323" alt="Screen Shot 2021-01-02 at 17 20 12" src="https://user-images.githubusercontent.com/1009191/103459249-f2a21c00-4d1e-11eb-9265-8d59fd384a3e.png">

Collapsed:
<img width="1197" alt="Screen Shot 2021-01-02 at 17 20 18" src="https://user-images.githubusercontent.com/1009191/103459250-f3d34900-4d1e-11eb-999a-f07a9a012b5e.png">