### PR TITLE
#185 :alien: Randomize peer lists on HomePage

### DIFF
--- a/pages/index.vue
+++ b/pages/index.vue
@@ -4,46 +4,52 @@
       <h1>
         <a href="https://github.com/cagataycali/find-mentor"> Feel free to contribute! </a>
       </h1>
-      <p class="pad-both">Every night & every deploy, the spread sheet will be parsed by GitHub actions, then generate this beauty.</p>
+      <p class="pad-both">
+        Every night & every deploy, the spread sheet will be parsed by GitHub actions, then generate this beauty.
+      </p>
       <div id="contribs">
         <ContribList :contribs="contribs" />
       </div>
       <nuxt-content :document="page" />
 
-      <cta-button class="upcoming-button" text="Upcoming Events" to="/events/" :nuxtLink="true" />
+      <cta-button class="upcoming-button" text="Upcoming Events" to="/events/" :nuxt-link="true" />
 
       <NuxtLink to="/guide/" class="how-it-works-link" :class="[{ 'how-it-works-link--visited': isVisitedGuide }]" title="How It Works?">
         How It Works?
       </NuxtLink>
     </header>
     <div class="container">
-      <hr />
+      <hr>
       <!-- Mentors -->
       <h2 class="title my-4">
         <NuxtLink to="/mentors/">
           👉 Mentors
-          <b-badge>({{ info.mentorCount }} people)</b-badge></NuxtLink
-        >
+          <b-badge>({{ info.mentorCount }} people)</b-badge>
+        </NuxtLink>
       </h2>
       <PersonList :persons="mentors" strict-type="mentors" />
-      <NuxtLink class="text-center d-block mb-5" to="/mentors/"> 🤳 Click here for all mentors </NuxtLink>
+      <NuxtLink class="text-center d-block mb-5" to="/mentors/">
+        🤳 Click here for all mentors
+      </NuxtLink>
 
       <!-- Mentees -->
       <h2 class="title mb-4 mt-5">
         <NuxtLink to="/mentees/">
           👉 Mentees
-          <b-badge>({{ info.menteeCount }} people)</b-badge></NuxtLink
-        >
+          <b-badge>({{ info.menteeCount }} people)</b-badge>
+        </NuxtLink>
       </h2>
       <PersonList :persons="mentees" strict-type="mentees" />
-      <NuxtLink class="text-center d-block mb-5" to="/mentees/"> 🤳 Click here for all mentees </NuxtLink>
+      <NuxtLink class="text-center d-block mb-5" to="/mentees/">
+        🤳 Click here for all mentees
+      </NuxtLink>
     </div>
   </div>
 </template>
 
 <script>
 export default {
-  async asyncData({ $content }) {
+  async asyncData ({ $content }) {
     const [mentors, mentees, page, info] = await Promise.all([
       $content('persons')
         .where({ mentor: { $in: ['Mentor', 'Both'] } })
@@ -56,7 +62,7 @@ export default {
         .limit(16)
         .fetch(),
       $content('readme').fetch(),
-      $content('info').fetch(),
+      $content('info').fetch()
     ])
     const { contribs } = await $content('contribs').fetch()
     return {
@@ -64,25 +70,25 @@ export default {
       mentees,
       contribs,
       page,
-      info,
+      info
     }
   },
-  data() {
+  data () {
     return {
-      isVisitedGuide: false,
+      isVisitedGuide: false
     }
   },
-  beforeMount() {
+  beforeMount () {
     this.checkGuideVisited()
   },
   methods: {
-    checkGuideVisited() {
+    checkGuideVisited () {
       const isVisited = window.localStorage.getItem('guideVisited')
 
       this.isVisitedGuide = isVisited
-    },
+    }
   },
-  head() {
+  head () {
     const title = 'Find Mentor & Mentees Network'
     const description = `${this.info.mentorCount} mentor is mentoring ${this.info.menteeCount} people, join us!`
     const icon = 'https://findmentor.network/icon.png'
@@ -92,56 +98,56 @@ export default {
         {
           hid: 'description',
           name: 'description',
-          content: description,
+          content: description
         },
         {
           hid: 'twitter:title',
           name: 'twitter:title',
-          content: title,
+          content: title
         },
         {
           hid: 'twitter:description',
           name: 'twitter:description',
-          content: description,
+          content: description
         },
         {
           hid: 'twitter:image',
           name: 'twitter:image',
-          content: icon,
+          content: icon
         },
         {
           hid: 'twitter:image:alt',
           name: 'twitter:image:alt',
-          content: description,
+          content: description
         },
         {
           hid: 'og:title',
           property: 'og:title',
-          content: title,
+          content: title
         },
         {
           hid: 'og:description',
           property: 'og:description',
-          content: description,
+          content: description
         },
         {
           hid: 'og:image',
           property: 'og:image',
-          content: icon,
+          content: icon
         },
         {
           hid: 'og:image:secure_url',
           property: 'og:image:secure_url',
-          content: icon,
+          content: icon
         },
         {
           hid: 'og:image:alt',
           property: 'og:image:alt',
-          content: description,
-        },
-      ],
+          content: description
+        }
+      ]
     }
-  },
+  }
 }
 </script>
 


### PR DESCRIPTION
#185 

- Artık Anasayfada mentor ve mentee listesindeki kişiler her defasında rastgele geliyor.
- AsyncData 'dan > Fetch'e geçirilerek anasayfa'ya geçiş öncesi artık bir önceki sayfada ssr beklemiyoruz. Anasayfa'ya anında geçiş yapılıyor veriler burada bekleniyor, beklenirken loading iconları görünmektedir.